### PR TITLE
removed prioritizeFastCharge type inconsistency

### DIFF
--- a/ChargingNode.cc
+++ b/ChargingNode.cc
@@ -46,7 +46,7 @@ void ChargingNode::initialize(int stage)
 
             //Initilize charge parameters
             chargeEffectivenessPercentage = double(par("chargeEffectivenessPercentage")) / 100;
-            prioritizeFastCharge = int(par("prioritizeFastCharge")) == 1;
+            prioritizeFastCharge = par("prioritizeFastCharge").boolValue();
 
             //Initialize chargeAlgorithm
             double linearGradient = double(par("linearGradient"));

--- a/ChargingNode.ned
+++ b/ChargingNode.ned
@@ -25,7 +25,7 @@ simple ChargingNode extends GenericNode
         double posY @unit("m") = default(0m);            // the starting coordinates in meter
         double batteryCapacity @unit("mAh") = default(0mAh); // the capacity of the ChargingStation in mAh
         double chargeEffectivenessPercentage = default(100.0); // the effectiveness of the battery in the Charging Station (100% - effectiveness = how much energy is wasted during charging)
-        int prioritizeFastCharge = default(0); 		 // when activated fast charged is prioritized over full charge
+        bool prioritizeFastCharge = default(false);      // when true fast charged is prioritized over full charge
         double chargeCurrent @unit("A") = default(1.0A); // the charging current, assumed as constant 
         int spotsWaiting = default(0);                   // the amount of spots a incoming node can wait on	
         int spotsCharging = default(0);                  // the amount of spots a node is charged on

--- a/omnetpp.ini
+++ b/omnetpp.ini
@@ -67,7 +67,7 @@ network = OsgEarthNet
 *.cs[*].chargeEffectivenessPercentage = 80
 *.cs[*].chargeCurrent = 3.5A
 *.cs[*].linearGradient = 0.2754
-*.cs[*].prioritizeFastCharge = 0
+*.cs[*].prioritizeFastCharge = false
 *.*.timeStep = 9000ms
 
 [Config multiUAV-Movement-Offline]


### PR DESCRIPTION
prioritizeFastCharge was decladed int in *.ned file but always used as bool in C++ code. Therefore ned file has been adjusted to also represent prioritizeFastCharge as bool.

Please review @LudwigBr 